### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,4 +1,6 @@
 name: Analyze
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/1](https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow appears to only check out code and run static analysis (with no steps that require write access to the repository or pull requests), the minimal permission of `contents: read` is sufficient. This can be set at the workflow level (top-level, applying to all jobs) or at the job level. The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made by adding the following block after the `name` field and before the `on` field:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
