### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/2](https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only needs to read repository contents (for checkout and running tests) and does not need to write to the repository or interact with issues or pull requests, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies to a specific job). The best practice is to set it at the workflow level unless a job requires different permissions. 

**Steps:**
- Add a `permissions:` block at the top level of `.github/workflows/test.yml` (after the `name:` and before `on:`).
- Set `contents: read` as the only permission.

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
