### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,4 +1,6 @@
 name: Style
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/3](https://github.com/RumenDamyanov/php-geolocation/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and does not perform any write operations (such as creating issues, pushing code, or modifying pull requests), the minimal permission required is `contents: read`. This can be set at the workflow level (top-level, applying to all jobs) or at the job level (inside the `style` job). The best practice is to set it at the workflow level unless a job requires different permissions. The change should be made at the top of the file, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
